### PR TITLE
feat: Criação inicial da role de runtime.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+Todas as mudanças importantes neste projeto serão documentas neste arquivo.
+
+O formato é baseado no [Mantenha um Changelog](https://keepachangelog.com/pt-BR/1.0.0/),
+e este projeto segue o [Versionamento Semântico](https://semver.org/lang/pt-BR/spec/v2.0.0.html).
+
+## [Não publicado]
+### Adicionado
+- Instalação e configuração de Docker e do módule de kernel de rede em bridge [[GH-1](https://github.com/mentoriaiac/iac_role_runtime/pull/1)]
+
+[Não publicado]: https://github.com/mentoriaiac/iac_role_runtime

--- a/README.md
+++ b/README.md
@@ -1,8 +1,13 @@
-# Template Role Ansible
+# iac_role_runtime
 
-![Pipeline Status](https://github.com/mentoriaiac/template-role-ansible/actions/workflows/ci.yml/badge.svg) 
+![Pipeline Status](https://github.com/mentoriaiac/iac_role_runtime/actions/workflows/ci.yml/badge.svg)
 
-Esse projeto tem a finalidade de ser um template para futuras criações de projetos que usem [ansible](https://docs.ansible.com/) e [molecule](https://molecule.readthedocs.io/en/latest/) (para teste do playbook).
+Esse projeto tem a finalidade de instalar e configurar componentes necessários
+para as partes de runtime da infraestrutura, como Kubernetes e Nomad.
+
+Atualmente as tarefas executadas por esse role são:
+  - Instalação e configuração do Docker.
+  - Habilitação e configuração do módule de kernel para redes em bridge.
 
 ## Dependências
 Para realizar os teste localmente é necessário a instalação das seguintes dependências:
@@ -42,4 +47,4 @@ Para realizar teste rápido após alguma modificação
 Ao termino do teste, destrua o ambiente
 ```bash
 (venv)$ molecule destroy
-``` 
+```

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,2 +1,6 @@
 ---
-# defaults file for nome_da_role
+runtime_install_docker: yes
+runtime_enable_bridge_network: yes
+
+runtime_docker_ce_version: "5:20.10.8~3-0~ubuntu-{{ ansible_distribution_release }}"
+runtime_containerd_version: "1.4.9-1"

--- a/files/daemon.json
+++ b/files/daemon.json
@@ -1,0 +1,10 @@
+{
+  "exec-opts": [
+    "native.cgroupdriver=systemd"
+  ],
+  "log-driver": "json-file",
+  "log-opts": {
+    "max-size": "100m"
+  },
+  "storage-driver": "overlay2"
+}

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,7 +1,7 @@
 galaxy_info:
-  author: your name
-  description: your role description
-  company: your company (optional)
+  author: "Felipe Nobrega - Dissipar - Mansur - Victor Braga - Roze Cardoso - Gazzinelli  - Gabriel Iglesias - CFLB - Juan Maia - Luiz Aoqui"
+  description: Role para instalar e configurar dependências de runtime.
+  company: Mentoria IaC
 
   # If the issue tracker for your role is not on github, uncomment the
   # next line and provide a value
@@ -14,7 +14,7 @@ galaxy_info:
   # - GPL-3.0-only
   # - Apache-2.0
   # - CC-BY-4.0
-  license: license (GPL-2.0-or-later, MIT, etc)
+  license: GPL-2.0-or-later
 
   min_ansible_version: 2.1
 
@@ -26,18 +26,10 @@ galaxy_info:
   # If you don't wish to enumerate all versions for a particular platform, use 'all'.
   # To view available platforms and versions (or releases), visit:
   # https://galaxy.ansible.com/api/v1/platforms/
-  #
-  # platforms:
-  # - name: Fedora
-  #   versions:
-  #   - all
-  #   - 25
-  # - name: SomePlatform
-  #   versions:
-  #   - all
-  #   - 1.0
-  #   - 7
-  #   - 99.99
+  platforms:
+    - name: Ubuntu
+      versions:
+        - 20.04
 
   galaxy_tags: []
     # List tags for your role here, one per line. A tag is a keyword that describes

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -2,6 +2,11 @@
 - name: Converge
   hosts: all
   tasks:
-    - name: "Include nome_da_role"
+    - name: instalado GNU PG2
+      apt:
+        update_cache: yes
+        name: gnupg2
+        state: present
+    - name: "Include iac_role_runtime"
       include_role:
-        name: "nome_da_role"
+        name: "iac_role_runtime"

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -4,8 +4,12 @@ dependency:
 driver:
   name: docker
 platforms:
-  - name: instance
-    image: docker.io/pycontribs/centos:8
+  - name: ubuntu-20-04-iac-role-runtime
+    image: "geerlingguy/docker-${MOLECULE_DISTRO:-ubuntu2004}-ansible:latest"
+    command: ${MOLECULE_DOCKER_COMMAND:-""}
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    privileged: true
     pre_build_image: true
 provisioner:
   name: ansible

--- a/tasks/bridge.yml
+++ b/tasks/bridge.yml
@@ -1,0 +1,17 @@
+---
+- name: "Bridge network : Instalação do module br_netfilter"
+  community.general.modprobe:
+    name: br_netfilter
+    state: present
+
+- name: "Bridge network : Configuração do iptables para br_netfilter"
+  ansible.posix.sysctl:
+    name: "{{ item }}"
+    sysctl_set: yes
+    value: "1"
+    reload: yes
+    sysctl_file: /etc/sysctl.d/20-net-bridge.conf
+  loop:
+    - "net.bridge.bridge-nf-call-arptables"
+    - "net.bridge.bridge-nf-call-ip6tables"
+    - "net.bridge.bridge-nf-call-iptables"

--- a/tasks/docker.yml
+++ b/tasks/docker.yml
@@ -1,0 +1,43 @@
+---
+- name: "Docker : Instalação dos pre-requisitos"
+  apt:
+    pkg:
+      - apt-transport-https
+      - ca-certificates
+    state: present
+    update_cache: yes
+
+- name: "Docker : Adicionando chaves gpg do repositório"
+  apt_key:
+    url: https://download.docker.com/linux/ubuntu/gpg
+    keyring: /usr/share/keyrings/docker-archive-keyring.gpg
+
+- name: "Docker : Instalando repositório apt"
+  apt_repository:
+    repo: >-
+      deb [arch=amd64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg]
+      https://download.docker.com/linux/ubuntu {{ ansible_distribution_release }} stable
+    state: present
+    filename: docker.list
+
+- name: "Docker : Criando diretorio /etc/docker"
+  file:
+    path: /etc/docker
+    recurse: yes
+    state: directory
+    mode: "0644"
+
+- name: "Docker : Copiando arquivo de configuração do daemon"
+  copy:
+    src: daemon.json
+    dest: /etc/docker/daemon.json
+    mode: "0644"
+
+- name: "Docker : Instalando pacotes"
+  apt:
+    pkg:
+      - "docker-ce={{ runtime_docker_ce_version }}"
+      - "docker-ce-cli={{ runtime_docker_ce_version }}"
+      - "containerd.io={{ runtime_containerd_version }}"
+    state: present
+    update_cache: yes

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,2 +1,5 @@
 ---
-# tasks file for nome_da_role
+- include_tasks: "docker.yml"
+  when: runtime_install_docker
+- include_tasks: "bridge.yml"
+  when: runtime_enable_bridge_network


### PR DESCRIPTION
# Criação inicial da role de runtime

A role de runtime instala e configura dependencias necessárias para os ambientes de runtime.

Esse PR adiciona as tasks iniciais, instalando o Docker e configurando o módulo de kernel to br_netfilter.

- [x] Garanta que seu **topic/feature/bugfix branch** tenha uma branch nomeada e não a sua branch main esteja no PR
- [x] Dê um titulo que expresse o objetivo do PR
- [x] Associe seu PR a uma Issue criada no repositósito. Caso seja uma correção de linguagem ou pequenas correções, não é necessário
- [x] Descreva o objetivo do PR
- [x] Inclua links relevantes para a sua modificação/sugestão/correção
- [x] Descreva um passo-a-passo para testar o seu PR

## Issue

N/A

## Objetivo

Criar uma role padrão para instalação e configuração de ambientes de runtime.

## Referências

- https://docs.docker.com/engine/install/ubuntu/
- https://www.nomadproject.io/docs/integrations/consul-connect#cni-plugins
- https://rancher.com/docs/rke/latest/en/os/#general-linux-requirements

## Como testar

Preparar o ambiente com Python e molecule como descrito no `README` e rodar o `molecule check`. 

```console
$ molecule check
```

Essa role depende de módulos de kernel do Linux. Para testar usando `molecule` com Docker alguns caminhos do host são montados dentro do container.

Para testar em ambientes não-Linux é necessário editar o arquivo `molecule/default/converge.yml` para desativar a configuração de módulos do kernel:

```diff
...
    - name: "Include iac_role_runtime"
      include_role:
        name: "iac_role_runtime"
+     vars:
+       runtime_enable_bridge_network: false
```