### PR TITLE
feat: configuração de cgroup driver do Docker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ e este projeto segue o [Versionamento Semântico](https://semver.org/lang/pt-BR/
 
 ## [Não publicado]
 
+### Adicionado
+- Configuração para cgroup driver do Docker [[GH-9](https://github.com/mentoriaiac/iac_role_runtime/pull/9)]
+
 ## [0.1.0] - 2021-10-05
 ### Adicionado
 - Instalação de dependencias básicas [[GH-3](https://github.com/mentoriaiac/iac_role_runtime/pull/3)]

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,4 +3,5 @@ runtime_install_docker: yes
 runtime_enable_bridge_network: yes
 
 runtime_docker_ce_version: "5:20.10.8~3-0~ubuntu-{{ ansible_distribution_release }}"
+runtime_docker_cgroup_driver: "cgroupfs"
 runtime_containerd_version: "1.4.9-1"

--- a/tasks/docker.yml
+++ b/tasks/docker.yml
@@ -28,8 +28,8 @@
     mode: "0644"
 
 - name: "Docker : Copiando arquivo de configuração do daemon"
-  ansible.builtin.copy:
-    src: daemon.json
+  ansible.builtin.template:
+    src: daemon.json.j2
     dest: /etc/docker/daemon.json
     mode: "0644"
 

--- a/templates/daemon.json.j2
+++ b/templates/daemon.json.j2
@@ -1,6 +1,6 @@
 {
   "exec-opts": [
-    "native.cgroupdriver=systemd"
+    "native.cgroupdriver={{ runtime_docker_cgroup_driver }}"
   ],
   "log-driver": "json-file",
   "log-opts": {


### PR DESCRIPTION
O valor pardrão para a configuração de cgroup driver do Docker é
cgroupfs e o Nomad precisa que esse seja o valor.

Adiciona uma variável para permitir a configuração desse valor se outra
opção for necessária.

- [x] Garanta que seu **topic/feature/bugfix branch** tenha uma branch nomeada e não a sua branch main esteja no PR
- [x] Dê um titulo que expresse o objetivo do PR
- [x] Associe seu PR a uma Issue criada no repositósito. Caso seja uma correção de linguagem ou pequenas correções, não é necessário
- [x] Descreva o objetivo do PR
- [x] Inclua links relevantes para a sua modificação/sugestão/correção
- [x] Descreva um passo-a-passo para testar o seu PR

## Issue

N/A

## Objetivo

Configurar o Docker damon da forma que o Nomad precisa.

## Referências

- https://github.com/hashicorp/nomad/issues/13022
- https://docs.docker.com/engine/reference/commandline/dockerd/#options-for-the-runtime

## Como testar

Em uma máquina Linux, rodar o `molecule converge` e verificar que o arquivo `/etc/docker/daemon.json` possui a configuração correta.
